### PR TITLE
Temperature guide is not a draft

### DIFF
--- a/content/guides/temperature.md
+++ b/content/guides/temperature.md
@@ -4,7 +4,6 @@ date: 2017-09-27
 linktitle: temperature
 title: Temperature controller
 highlight: true
-draft: true
 weight: 6
 keywords:
 - reef-pi


### PR DESCRIPTION
Remove the draft document attribute from the temperature guide to be this guide available in the documentation.